### PR TITLE
fix: copy README.md in Dockerfiles before install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Set working directory
 WORKDIR /app
 
-# Copy dependency files first (for layer caching)
-COPY pyproject.toml .
-COPY uv.lock .
+# Copy dependency and metadata files first (for layer caching)
+COPY pyproject.toml uv.lock README.md LICENSE ./
 
 # Create venv and install dependencies
 RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -6,9 +6,8 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Set working directory
 WORKDIR /app
 
-# Copy dependency files first (for layer caching)
-COPY pyproject.toml .
-COPY uv.lock .
+# Copy dependency and metadata files first (for layer caching)
+COPY pyproject.toml uv.lock README.md LICENSE ./
 
 # Create venv and install dependencies
 RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .


### PR DESCRIPTION
## Summary

Fixes deployment failure caused by hatchling requiring `README.md` at build time. The Dockerfiles copy `pyproject.toml` and `uv.lock` early for layer caching, but `pyproject.toml` declares `readme = "README.md"` — which wasn't present during `uv pip install .`, causing `OSError: Readme file does not exist: README.md`.

## Key Changes

- **`Dockerfile`**: Add `README.md` to the early `COPY` step alongside `pyproject.toml` and `uv.lock`
- **`Dockerfile.local`**: Same fix

## Testing

- Deployment logs confirmed the `OSError` is resolved by having `README.md` present during the build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)