### PR TITLE
fix: allow README.md and LICENSE through .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,4 @@ __pycache__/
 .git/
 tests/
 *.md
-LICENSE
+!README.md


### PR DESCRIPTION
## Summary

Fixes deployment failure after PR #32. The `.dockerignore` excludes `*.md` and `LICENSE`, which prevents Docker from copying these files into the build context. But hatchling needs `README.md` (declared as `readme` in `pyproject.toml`) at build time, and `LICENSE` is referenced by the `COPY` instruction added in #32.

## Root Cause

The `.dockerignore` had:
```
*.md
LICENSE
```

This stripped both files from the Docker build context, causing:
```
COPY pyproject.toml uv.lock README.md LICENSE ./
ERROR: "/LICENSE": not found
```

## Fix

- Add `!README.md` negation pattern to override the `*.md` exclusion
- Remove `LICENSE` from the exclusion list (1KB file, no reason to exclude)

Other markdown files (`CLAUDE.md`, `FORMULAS.md`) remain excluded.

## Testing

- Verified `.dockerignore` negation syntax is correct (same as `.gitignore`)
- Docker not available locally; relies on CD pipeline to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)