### PR TITLE
fix: move COPY src/ before install step in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Set working directory
 WORKDIR /app
 
-# Copy project files needed for install
+# Copy dependency metadata first (for layer caching)
 COPY pyproject.toml uv.lock README.md LICENSE ./
-COPY src/ ./src/
 
-# Create venv and install the package (hatchling needs src/ to build the wheel)
-RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .
+# Install dependencies only (cached until pyproject.toml or uv.lock change)
+RUN uv sync --frozen --no-install-project --no-dev
+
+# Copy source and install the local package
+COPY src/ ./src/
+RUN uv sync --frozen --no-dev
 
 # Expose Streamlit port
 EXPOSE 8501

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Set working directory
 WORKDIR /app
 
-# Copy dependency and metadata files first (for layer caching)
+# Copy project files needed for install
 COPY pyproject.toml uv.lock README.md LICENSE ./
-
-# Create venv and install dependencies
-RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .
-
-# Copy application code
 COPY src/ ./src/
+
+# Create venv and install the package (hatchling needs src/ to build the wheel)
+RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .
 
 # Expose Streamlit port
 EXPOSE 8501

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -6,12 +6,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Set working directory
 WORKDIR /app
 
-# Copy project files needed for install
+# Copy dependency metadata first (for layer caching)
 COPY pyproject.toml uv.lock README.md LICENSE ./
-COPY src/ ./src/
 
-# Create venv and install the package (hatchling needs src/ to build the wheel)
-RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .
+# Install dependencies only (cached until pyproject.toml or uv.lock change)
+RUN uv sync --frozen --no-install-project --no-dev
+
+# Copy source and install the local package
+COPY src/ ./src/
+RUN uv sync --frozen --no-dev
 
 # Expose Streamlit port
 EXPOSE 8501

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -6,14 +6,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 # Set working directory
 WORKDIR /app
 
-# Copy dependency and metadata files first (for layer caching)
+# Copy project files needed for install
 COPY pyproject.toml uv.lock README.md LICENSE ./
-
-# Create venv and install dependencies
-RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .
-
-# Copy application code
 COPY src/ ./src/
+
+# Create venv and install the package (hatchling needs src/ to build the wheel)
+RUN uv venv /app/.venv && uv pip install --python /app/.venv/bin/python --no-cache .
 
 # Expose Streamlit port
 EXPOSE 8501


### PR DESCRIPTION
## Summary

Fixes `ModuleNotFoundError: No module named 'simulator'` in the deployed Streamlit app after PR #31 merged.

## Root Cause

PR #31 moved `app.py` into the `src/simulator/` package and removed the `sys.path.insert` hack. The app now relies on the package being properly installed for `from simulator.engine import ...` to work.

But the Dockerfile copied `src/` **after** the install step:

```dockerfile
RUN uv pip install .     # <- hatchling can't find src/simulator/ yet
COPY src/ ./src/          # <- too late, package wasn't built
```

hatchling needs `src/simulator/` present to build the wheel. Without it, the `simulator` package was never installed.

## Fix

Move `COPY src/ ./src/` before the `RUN uv pip install` step in both Dockerfiles.

## Testing

- Built locally with Docker: `rent-vs-buy-simulator==1.0.0` correctly installed
- Streamlit starts without errors
- HTTP 200 on `localhost:8501`

🤖 Generated with [Claude Code](https://claude.com/claude-code)