### PR TITLE
feat: adaptive symlog scale, breakdown label fix, 25yr mortgage term

### DIFF
--- a/src/simulator/static/js/charts.js
+++ b/src/simulator/static/js/charts.js
@@ -1,8 +1,6 @@
 // Plotly.js builders — one shared GitHub-dark theme. Buy #f0883e,
 // Rent #58a6ff; bands/neutrals muted; direct line labels, no legends.
 
-import { fmtCompact } from "./format.js";
-
 const BUY = "#f0883e";
 const RENT = "#58a6ff";
 const MUTED = "#8b949e";
@@ -64,10 +62,22 @@ function outcomesDisparate(buyY, rentY) {
   return Math.max(a, b) / Math.max(Math.min(a, b), 1) >= SCALE_DISPARITY;
 }
 
+// Compact tick label ($1k / $30k / $1.0M). Like fmtCompact but compacts down
+// to $1k so a symlog axis never mixes "$1,000" with "$10k".
+function fmtTick(v) {
+  const sign = v < 0 ? "-" : "";
+  const a = Math.abs(v);
+  if (a >= 1e6) return `${sign}$${(a / 1e6).toFixed(1)}M`;
+  if (a >= 1e3) return `${sign}$${Math.round(a / 1e3)}k`;
+  return `${sign}$${Math.round(a)}`;
+}
+
 // Nice dollar tick values (…, -1M, -300k, 0, 300k, 1M, …) at 1x/3x per decade
 // across the top ~3 decades of the range, clipped to the data's [min, max].
 // Limiting to the top decades keeps labels from crowding near zero, where
 // symlog compresses every decade into a shrinking band.
+// Precondition: peak > 0 (guaranteed by maybeSymlog's guard) — a zero peak
+// makes topExp -Infinity and the loop below never terminates.
 function symlogTicks(min, max) {
   const peak = Math.max(Math.abs(min), Math.abs(max));
   const topExp = Math.floor(Math.log10(peak));
@@ -86,15 +96,24 @@ function symlogTicks(min, max) {
 // caller to plot data and annotations through. Returns null to keep linear.
 function maybeSymlog(layout, buyY, rentY) {
   if (!outcomesDisparate(buyY, rentY)) return null;
-  const all = [...buyY, ...rentY];
-  const peak = Math.max(...all.map((v) => Math.abs(v)));
+  // One pass for the data range — no spreading the full monthly series into
+  // Math.min/max(...), which would cap out on the argument count as it grows.
+  let min = Infinity;
+  let max = -Infinity;
+  for (const arr of [buyY, rentY]) {
+    for (const v of arr) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+  }
+  const peak = Math.max(Math.abs(min), Math.abs(max));
   if (!(peak > 0)) return null;
   const t = peak / 1e4; // linear knee at 0.01% of peak; everything else compresses
   const fwd = (y) => symlogFwd(y, t);
-  const ticks = symlogTicks(Math.min(...all), Math.max(...all));
+  const ticks = symlogTicks(min, max);
   layout.yaxis.tickmode = "array";
   layout.yaxis.tickvals = ticks.map(fwd);
-  layout.yaxis.ticktext = ticks.map((v) => fmtCompact(v));
+  layout.yaxis.ticktext = ticks.map(fmtTick);
   delete layout.yaxis.tickformat;
   return fwd;
 }

--- a/src/simulator/static/js/charts.js
+++ b/src/simulator/static/js/charts.js
@@ -1,6 +1,8 @@
 // Plotly.js builders — one shared GitHub-dark theme. Buy #f0883e,
 // Rent #58a6ff; bands/neutrals muted; direct line labels, no legends.
 
+import { fmtCompact } from "./format.js";
+
 const BUY = "#f0883e";
 const RENT = "#58a6ff";
 const MUTED = "#8b949e";
@@ -21,24 +23,87 @@ function baseLayout(xTitle) {
   };
 }
 
-function strategyTraces(x, buyY, rentY) {
+// `fwd`, when given, maps dollars to symlog space (see maybeSymlog). The raw
+// dollar value rides along in customdata so hover still reads in dollars.
+function strategyTraces(x, buyY, rentY, fwd) {
+  const mk = (yRaw, color, name) => {
+    const base = { x, mode: "lines", line: { color, width: 2 }, name };
+    return fwd
+      ? { ...base, y: yRaw.map(fwd), customdata: yRaw, hovertemplate: `${name} %{customdata:$,.0f}<extra></extra>` }
+      : { ...base, y: yRaw, hovertemplate: `${name} %{y:$,.0f}<extra></extra>` };
+  };
+  return [mk(buyY, BUY, "Buy"), mk(rentY, RENT, "Rent")];
+}
+
+function endLabelAnnotations(x, buyY, rentY, fwd) {
+  const y = (v) => (fwd ? fwd(v) : v);
   return [
-    { x, y: buyY, mode: "lines", line: { color: BUY, width: 2 }, name: "Buy", hovertemplate: "Buy %{y:$,.0f}<extra></extra>" },
-    { x, y: rentY, mode: "lines", line: { color: RENT, width: 2 }, name: "Rent", hovertemplate: "Rent %{y:$,.0f}<extra></extra>" },
+    { x: x.at(-1), y: y(buyY.at(-1)), text: "Buy", font: { color: BUY, size: 12 }, showarrow: false, xanchor: "left", xshift: 6 },
+    { x: x.at(-1), y: y(rentY.at(-1)), text: "Rent", font: { color: RENT, size: 12 }, showarrow: false, xanchor: "left", xshift: 6 },
   ];
 }
 
-function endLabelAnnotations(x, buyY, rentY) {
-  return [
-    { x: x.at(-1), y: buyY.at(-1), text: "Buy", font: { color: BUY, size: 12 }, showarrow: false, xanchor: "left", xshift: 6 },
-    { x: x.at(-1), y: rentY.at(-1), text: "Rent", font: { color: RENT, size: 12 }, showarrow: false, xanchor: "left", xshift: 6 },
-  ];
+// --- Adaptive y-scale ----------------------------------------------------
+// Net-worth and outflow curves can span orders of magnitude at long horizons.
+// When the two final outcomes diverge by at least this factor, a linear axis
+// squashes the smaller curve against the baseline, so we switch to a symlog
+// scale: sign-preserving, ~linear near zero, log-like for large magnitudes.
+const SCALE_DISPARITY = 10;
+
+// Symlog forward transform. `t` is the linear-region half-width: below |t| the
+// mapping is ~linear (so it survives sign changes and zero crossings), above it
+// compresses logarithmically.
+function symlogFwd(y, t) {
+  return Math.sign(y) * Math.log10(1 + Math.abs(y) / t);
+}
+
+// True when the larger final outcome dwarfs the smaller by >= SCALE_DISPARITY.
+function outcomesDisparate(buyY, rentY) {
+  const a = Math.abs(buyY.at(-1));
+  const b = Math.abs(rentY.at(-1));
+  return Math.max(a, b) / Math.max(Math.min(a, b), 1) >= SCALE_DISPARITY;
+}
+
+// Nice dollar tick values (…, -1M, -300k, 0, 300k, 1M, …) at 1x/3x per decade
+// across the top ~3 decades of the range, clipped to the data's [min, max].
+// Limiting to the top decades keeps labels from crowding near zero, where
+// symlog compresses every decade into a shrinking band.
+function symlogTicks(min, max) {
+  const peak = Math.max(Math.abs(min), Math.abs(max));
+  const topExp = Math.floor(Math.log10(peak));
+  const vals = new Set([0]);
+  for (let e = topExp - 2; e <= topExp; e++) {
+    for (const m of [1, 3]) {
+      vals.add(m * 10 ** e);
+      vals.add(-m * 10 ** e);
+    }
+  }
+  return [...vals].filter((v) => v >= min && v <= max).sort((a, b) => a - b);
+}
+
+// If the two series' outcomes are disparate, install a symlog y-axis on
+// `layout` (custom dollar ticks) and return the forward transform for the
+// caller to plot data and annotations through. Returns null to keep linear.
+function maybeSymlog(layout, buyY, rentY) {
+  if (!outcomesDisparate(buyY, rentY)) return null;
+  const all = [...buyY, ...rentY];
+  const peak = Math.max(...all.map((v) => Math.abs(v)));
+  if (!(peak > 0)) return null;
+  const t = peak / 1e4; // linear knee at 0.01% of peak; everything else compresses
+  const fwd = (y) => symlogFwd(y, t);
+  const ticks = symlogTicks(Math.min(...all), Math.max(...all));
+  layout.yaxis.tickmode = "array";
+  layout.yaxis.tickvals = ticks.map(fwd);
+  layout.yaxis.ticktext = ticks.map((v) => fmtCompact(v));
+  delete layout.yaxis.tickformat;
+  return fwd;
 }
 
 export function renderDecisionChart(el, series, breakevenYear) {
   const x = series.year;
   const layout = baseLayout("Years");
-  layout.annotations = endLabelAnnotations(x, series.netBuy, series.netRent);
+  const fwd = maybeSymlog(layout, series.netBuy, series.netRent);
+  layout.annotations = endLabelAnnotations(x, series.netBuy, series.netRent, fwd);
   if (breakevenYear != null) {
     layout.shapes = [
       { type: "line", x0: breakevenYear, x1: breakevenYear, yref: "paper", y0: 0, y1: 1, line: { color: "#484f58", width: 1, dash: "dash" } },
@@ -48,7 +113,7 @@ export function renderDecisionChart(el, series, breakevenYear) {
       text: `breakeven ${breakevenYear.toFixed(1)}y`, font: { color: MUTED, size: 11 }, showarrow: false,
     });
   }
-  Plotly.react(el, strategyTraces(x, series.netBuy, series.netRent), layout, PLOT_CONFIG);
+  Plotly.react(el, strategyTraces(x, series.netBuy, series.netRent, fwd), layout, PLOT_CONFIG);
 }
 
 export function renderFanChart(el, mc) {
@@ -80,6 +145,7 @@ export function renderTornadoChart(el, tornado) {
   ];
   const layout = baseLayout("Impact on Buy − Rent difference");
   layout.barmode = "overlay";
+  layout.yaxis.automargin = true; // grow the left margin to fit parameter labels
   layout.shapes = [
     { type: "line", x0: base, x1: base, yref: "paper", y0: 0, y1: 1, line: { color: "#e6edf3", width: 1 } },
   ];
@@ -89,8 +155,9 @@ export function renderTornadoChart(el, tornado) {
 export function renderOutflowChart(el, series) {
   const x = series.year;
   const layout = baseLayout("Years");
-  layout.annotations = endLabelAnnotations(x, series.outflowBuy, series.outflowRent);
-  Plotly.react(el, strategyTraces(x, series.outflowBuy, series.outflowRent), layout, PLOT_CONFIG);
+  const fwd = maybeSymlog(layout, series.outflowBuy, series.outflowRent);
+  layout.annotations = endLabelAnnotations(x, series.outflowBuy, series.outflowRent, fwd);
+  Plotly.react(el, strategyTraces(x, series.outflowBuy, series.outflowRent, fwd), layout, PLOT_CONFIG);
 }
 
 export function renderBreakdownChart(el, payload, cfg) {
@@ -118,5 +185,6 @@ export function renderBreakdownChart(el, payload, cfg) {
     },
   ];
   const layout = baseLayout(`Total over ${cfg.horizonYears} years`);
+  layout.yaxis.automargin = true; // grow the left margin to fit category labels
   Plotly.react(el, traces, layout, PLOT_CONFIG);
 }

--- a/src/simulator/static/js/fields.js
+++ b/src/simulator/static/js/fields.js
@@ -9,7 +9,7 @@ export const INPUT_DEFS = [
   { key: "propertyPrice", label: "Home price", min: 50000, max: 2000000, step: 5000, fmt: fmtCompact, section: "core", hint: "Purchase price of the property" },
   { key: "downPaymentPct", label: "Down payment", min: 5, max: 50, step: 1, fmt: (v) => fmtPct(v, 0), section: "core" },
   { key: "mortgageRateAnnual", label: "Mortgage rate", min: 1, max: 10, step: 0.05, fmt: (v) => fmtPct(v, 2), section: "core" },
-  { key: "mortgageTermYears", label: "Mortgage term", type: "segmented", options: [15, 20, 30], section: "core", hint: "Amortization period — independent of the horizon" },
+  { key: "mortgageTermYears", label: "Mortgage term", type: "segmented", options: [15, 20, 25, 30], section: "core", hint: "Amortization period — independent of the horizon" },
   { key: "monthlyRent", label: "Monthly rent", min: 500, max: 10000, step: 50, fmt: fmtMoney, section: "core" },
   { key: "horizonYears", label: "Horizon", min: 2, max: 40, step: 1, fmt: (v) => `${v} yrs`, section: "core", hint: "Years until you'd sell — the chart x-axis ends here" },
   { key: "propertyAppreciationAnnual", label: "Property appreciation", min: 0, max: 10, step: 0.1, fmt: (v) => fmtPct(v), section: "assumptions" },


### PR DESCRIPTION
## Summary

Three small frontend fixes to the charts and inputs: stop long chart labels from being clipped, make the net-value scale readable when outcomes diverge by orders of magnitude, and add a 25-year mortgage term. Backend and engine are untouched.

## Key Changes

### Chart label clipping (`renderBreakdownChart`, `renderTornadoChart`)
- Set `yaxis.automargin` on the two horizontal-bar charts so Plotly grows the left margin to fit labels like "Mortgage interest" and "Tax savings (offset)", which were previously cut off by the fixed `l: 56` margin.

### Adaptive symlog scale (net-value & outflow charts)
- At long horizons with a large gap between strategies, the smaller curve collapses against the baseline on a linear axis. When the two final outcomes differ by ≥ 10× in magnitude, the axis now switches to a **symlog** scale.
- **Why symlog, not log:** net value is a *signed* quantity (net of committed cash) that is negative for much of the timeline and crosses zero — a plain log axis can't render ≤ 0 values, so it would fall back to linear in exactly the disparate cases we care about. Symlog is sign-preserving: ~linear near zero, log-like for large ± magnitudes.
- Implemented as a data transform + custom dollar tick labels, with the true dollar value carried in `customdata` so hover still reads in dollars. Non-disparate views (the common case) stay linear and visually unchanged. Outflow is always positive and rarely disparate, so it stays linear almost always.

### 25-year mortgage term (`fields.js`)
- Added `25` to the segmented options (`[15, 20, 30]` → `[15, 20, 25, 30]`). The backend already validates any term in `1..100`, so this is UI-only.

## Review Guide

**Focus on** `charts.js` — the adaptive-scale helpers (`symlogFwd`, `outcomesDisparate`, `symlogTicks`, `maybeSymlog`) and the `SCALE_DISPARITY = 10` threshold. The threshold is a named constant, easy to tune.

**Safe to skim** the one-line `fields.js` change and the two `automargin` lines.

## Testing

- `uv run pytest tests/` → 60 passed; `uv run ruff check src/ tests/` → clean (backend/engine unchanged).
- Symlog transform + tick generation validated numerically.
- Verified in the running app (Playwright): 25-year button renders; breakdown labels no longer clipped; a high-disparity scenario (40y, 9% appreciation, 5% equity → Buy $9.2M vs Rent $704k) engages symlog with ticks `-$300k … $0 … $3.0M`, de-squashing the Rent curve; default and outflow views stay linear; no console errors.

## Breaking Changes

None. Backward compatible; no API or engine changes.
