### PR TITLE
fix: label the money axis and perturb the tornado by the standard error

### DIFF
--- a/FORMULAS.md
+++ b/FORMULAS.md
@@ -428,8 +428,37 @@ defined metric.
 
 The tornado chart does not. It is one-at-a-time sensitivity on the
 *deterministic* engine: for each candidate parameter it re-runs
-`calculate_scenarios` at ±1 standard deviation and reads
-`final_difference`. The MC paths are not involved.
+`calculate_scenarios` at a perturbed value and reads `final_difference`.
+The MC paths are not involved.
+
+The perturbation width differs by parameter kind:
+
+| Parameter kind | Delta |
+|---|---|
+| Stochastic drivers (property appreciation, equity growth, rent inflation) | `σ / √horizon` |
+| Property levy, either representation | `± 41.7%` of its own base |
+| Everything else (price, down payment, rent, mortgage rate) | a fixed absolute step |
+
+The `√horizon` matters. `σ` is the *annual* standard deviation, which is
+what the Monte Carlo needs — it redraws every year, so year-to-year
+dispersion is the right scale. The tornado instead shifts the single
+long-run average and holds it for the whole horizon, so the uncertainty
+that applies is the uncertainty of that **average**: the standard error,
+`σ / √N`. At 22 years a 15pp annual σ is a 3.2pp standard error.
+
+Conflating the two moved a 9% equity CAGR to 24% and held it there,
+which over 22 years compounded a €150k outlay into roughly €17M and
+produced a bar an order of magnitude wider than the rest of the chart
+combined.
+
+A high perturbation is additionally capped at the parameter's slider
+maximum, so the chart never measures a configuration the app cannot be
+set to. That cap is one-sided: the low side may fall below the slider
+minimum, because a crash is a real outcome the model has to represent
+even though the UI will not let you type a negative growth rate. The cap
+never pulls the high side below the base — the engine accepts bases above
+the slider maximum, and clamping alone put the "higher" bar below the
+"lower" one.
 
 Two details are region-specific. Both levy fields — ad-valorem
 `property_tax_rate` and flat `annual_property_levy` — take a **relative**

--- a/src/simulator/monte_carlo.py
+++ b/src/simulator/monte_carlo.py
@@ -31,6 +31,33 @@ _LEVY_RELATIVE_DELTA = 0.5 / 1.2
 # relative) and far below any swing a user could read off the chart.
 _NEGLIGIBLE_SWING_RATIO = 1e-6
 
+# Highest value the UI lets a user set for each perturbed field, in
+# STORED units. A high perturbation is capped here so the tornado never
+# measures a scenario the app cannot be configured to produce: equity
+# growth was swinging to +1 sigma = 24% against a slider that stops at
+# 15%, and over a long horizon that compounds into a bar an order of
+# magnitude wider than every other one put together, collapsing the rest
+# of the chart into slivers.
+#
+# The LOW side is deliberately NOT capped at the slider minimum. A crash
+# is a real outcome the model must be able to represent even though the
+# UI will not let you type a negative growth rate -- see
+# test_tornado_low_uses_negative_growth_rate, which pins that.
+#
+# Mirrors fields.js. Kept honest by tests/test_tornado_bounds.py, which
+# parses the slider maxima out of it rather than trusting this copy.
+_PERTURBATION_CEILING = {
+    "property_appreciation_annual": 10.0,
+    "equity_growth_annual": 15.0,
+    "rent_inflation_rate": 0.1,
+    "property_price": 2_000_000.0,
+    "down_payment_pct": 50.0,
+    "monthly_rent": 10_000.0,
+    "mortgage_rate_annual": 10.0,
+    "property_tax_rate": 5.0,
+    "annual_property_levy": 10_000.0,
+}
+
 
 def _is_negligible_against(swing: float, reference: float) -> bool:
     """Whether ``swing`` is rounding noise at the scale of ``reference``.
@@ -368,12 +395,11 @@ def _compute_sensitivity(  # noqa: C901
         if field == "rent_inflation_rate":
             low_override = max(low_override, 0.0)
 
-        # High perturbation (add delta)
+        # High perturbation (add delta), never past what the UI can set.
         high_override = base_val + delta
-        if field == "down_payment_pct":
-            high_override = min(high_override, 100.0)
-        if field == "rent_inflation_rate":
-            high_override = min(high_override, 1.0)
+        ceiling = _PERTURBATION_CEILING.get(field)
+        if ceiling is not None:
+            high_override = min(high_override, ceiling)
 
         try:
             val_low = _run_with_override(**{field: low_override})

--- a/src/simulator/monte_carlo.py
+++ b/src/simulator/monte_carlo.py
@@ -7,6 +7,8 @@ deterministic verdict (ADR-0001, ADR-0003).
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 
 from .engine import _net_value_series
@@ -16,10 +18,12 @@ from .models import (
     SimulationConfig,
 )
 
-# Lower bound for the tornado's low perturbation on positive-only fields.
-# The proportional levy delta is checked against this same value, so the
-# guard and the clamp cannot drift apart.
-_LOW_PERTURBATION_FLOOR = 0.001
+# Smallest value a positive-only field may be perturbed to. A NUMERIC
+# safety floor, unrelated to _UI_MAXIMUM below, which is a per-field UI
+# policy -- the names are not an antonym pair. The proportional levy
+# delta is checked against this same value so guard and clamp cannot
+# drift apart.
+_POSITIVE_FIELD_FLOOR = 0.001
 
 # Relative swing applied to whichever field carries a region's property
 # levy. Calibrated so the US ad-valorem base of 1.2 keeps its historical
@@ -31,13 +35,37 @@ _LEVY_RELATIVE_DELTA = 0.5 / 1.2
 # relative) and far below any swing a user could read off the chart.
 _NEGLIGIBLE_SWING_RATIO = 1e-6
 
+# Fields whose tornado delta is an ANNUAL standard deviation.
+#
+# That sigma is what run_monte_carlo needs: it generates a fresh draw
+# every year, so year-to-year dispersion is exactly the right scale. The
+# tornado asks a different question. It shifts the deterministic engine's
+# single long-run average and holds it for the whole horizon, so the
+# relevant uncertainty is the uncertainty of that AVERAGE -- the standard
+# error, sigma / sqrt(horizon).
+#
+# Using the raw annual sigma conflated the two. At 22 years it moved a 9%
+# equity CAGR to 24% and held it there, compounding a 150k initial outlay
+# into ~17M and producing a bar an order of magnitude wider than the rest
+# of the chart combined. The standard error at that horizon is 3.2pp, not
+# 15pp.
+#
+# The remaining perturbations are fixed absolute steps (a 100k price
+# move, 5pp of down payment), not standard deviations, so sqrt(horizon)
+# does not apply to them.
+_STOCHASTIC_FIELDS = frozenset(
+    {
+        "property_appreciation_annual",
+        "equity_growth_annual",
+        "rent_inflation_rate",
+    }
+)
+
 # Highest value the UI lets a user set for each perturbed field, in
-# STORED units. A high perturbation is capped here so the tornado never
-# measures a scenario the app cannot be configured to produce: equity
-# growth was swinging to +1 sigma = 24% against a slider that stops at
-# 15%, and over a long horizon that compounds into a bar an order of
-# magnitude wider than every other one put together, collapsing the rest
-# of the chart into slivers.
+# STORED units. With the standard-error delta above, a perturbation
+# rarely reaches this -- it is the guard for a base that is already at or
+# beyond the slider maximum, which the engine accepts (down payment is
+# valid to 100, the slider stops at 50) and the API will hand over.
 #
 # The LOW side is deliberately NOT capped at the slider minimum. A crash
 # is a real outcome the model must be able to represent even though the
@@ -46,7 +74,7 @@ _NEGLIGIBLE_SWING_RATIO = 1e-6
 #
 # Mirrors fields.js. Kept honest by tests/test_tornado_bounds.py, which
 # parses the slider maxima out of it rather than trusting this copy.
-_PERTURBATION_CEILING = {
+_UI_MAXIMUM = {
     "property_appreciation_annual": 10.0,
     "equity_growth_annual": 15.0,
     "rent_inflation_rate": 0.1,
@@ -369,6 +397,12 @@ def _compute_sensitivity(  # noqa: C901
         # folded-EWF 0.2815 is a +-178% swing implying WOZ regimes it
         # does not have. _LEVY_RELATIVE_DELTA is calibrated so the US
         # base of 1.2 keeps its historical delta of exactly 0.5.
+        # An annual sigma is the dispersion of ONE year. The tornado holds
+        # its shift for the whole horizon, so the uncertainty that applies
+        # is that of the long-run average: the standard error.
+        if field in _STOCHASTIC_FIELDS:
+            delta = delta / math.sqrt(base_config.horizon_years)
+
         if field in ("property_tax_rate", "annual_property_levy"):
             delta = base_val * _LEVY_RELATIVE_DELTA
             # Skip whenever the low side would hit the floor below. That
@@ -378,7 +412,7 @@ def _compute_sensitivity(  # noqa: C901
             # 0.000706 it exceeds the high side outright, rendering the
             # bar inverted. Reachable from the UI -- fields.js ships
             # propertyTaxRate with step 0.0005 from a min of 0.
-            if base_val - delta < _LOW_PERTURBATION_FLOOR:
+            if base_val - delta < _POSITIVE_FIELD_FLOOR:
                 continue
 
         # Low perturbation (subtract delta). Growth rates may legitimately
@@ -387,7 +421,7 @@ def _compute_sensitivity(  # noqa: C901
         if field in ("property_appreciation_annual", "equity_growth_annual"):
             low_override = max(base_val - delta, -99.0)
         else:
-            low_override = max(base_val - delta, _LOW_PERTURBATION_FLOOR)
+            low_override = max(base_val - delta, _POSITIVE_FIELD_FLOOR)
         # Clamp down_payment_pct to [5, 100]
         if field == "down_payment_pct":
             low_override = max(low_override, 5.0)
@@ -396,10 +430,25 @@ def _compute_sensitivity(  # noqa: C901
             low_override = max(low_override, 0.0)
 
         # High perturbation (add delta), never past what the UI can set.
+        #
+        # The outer max() is load-bearing, not defensive. The engine
+        # accepts bases ABOVE the slider maximum (down_payment_pct is
+        # valid to 100, the slider stops at 50) and a config can arrive
+        # that way through the API. Clamping to the ceiling alone would
+        # then put the "higher" bar BELOW the base -- and below the
+        # "lower" bar -- so both bars land on the same side of the pivot
+        # and the one labelled "higher" shows the outcome of a DECREASE.
+        # It also let a proportional levy delta land low and high on the
+        # ceiling together, collapsing the swing to zero so the
+        # negligible-swing guard silently deleted a real bar.
+        #
+        # At base == ceiling this leaves the high half zero-width, which
+        # is the honest reading: at the maximum the parameter can only
+        # go down. The bar still renders at full width from the low side.
         high_override = base_val + delta
-        ceiling = _PERTURBATION_CEILING.get(field)
+        ceiling = _UI_MAXIMUM.get(field)
         if ceiling is not None:
-            high_override = min(high_override, ceiling)
+            high_override = max(base_val, min(high_override, ceiling))
 
         try:
             val_low = _run_with_override(**{field: low_override})

--- a/src/simulator/static/js/charts.js
+++ b/src/simulator/static/js/charts.js
@@ -37,7 +37,11 @@ function baseLayout(xTitle) {
 // It cannot simply be set on both: Plotly ignores a tickformat on a
 // category axis but honours a tickprefix, so a prefix left on Y labels
 // every category "<symbol>Rent Inflation".
+// Not idempotent by construction, so it refuses to run twice: a second
+// call would read the already-deleted y-axis keys and assign undefined,
+// silently wiping the currency it just installed.
 function moveCurrencyToXAxis(layout) {
+  if (layout.yaxis.tickprefix === undefined) return;
   layout.xaxis.tickprefix = layout.yaxis.tickprefix;
   layout.xaxis.tickformat = layout.yaxis.tickformat;
   delete layout.yaxis.tickprefix;

--- a/src/simulator/static/js/charts.js
+++ b/src/simulator/static/js/charts.js
@@ -29,11 +29,17 @@ function baseLayout(xTitle) {
 }
 
 // Horizontal-bar charts put money on X and categories on Y, so the base
-// layout's currency prefix has to come off the Y axis. It matters because
-// Plotly ignores a tickformat on a category axis but honours a tickprefix
-// -- so the prefix would label every parameter name "<symbol>Rent
-// Inflation".
-function clearCurrencyFromYAxis(layout) {
+// layout's money formatting has to MOVE axes, not just come off Y.
+// Deleting it alone left the money axis with no currency and no SI
+// compaction at all -- the tornado read "-0.5M" where every other chart
+// reads "-EUR500k".
+//
+// It cannot simply be set on both: Plotly ignores a tickformat on a
+// category axis but honours a tickprefix, so a prefix left on Y labels
+// every category "<symbol>Rent Inflation".
+function moveCurrencyToXAxis(layout) {
+  layout.xaxis.tickprefix = layout.yaxis.tickprefix;
+  layout.xaxis.tickformat = layout.yaxis.tickformat;
   delete layout.yaxis.tickprefix;
   delete layout.yaxis.tickformat;
 }
@@ -182,7 +188,7 @@ export function renderTornadoChart(el, tornado) {
     { type: "bar", orientation: "h", y: params, x: high, base, marker: { color: RENT }, hovertemplate: `%{y} higher: ${getCurrencySymbol()}%{x:,.0f}<extra></extra>` },
   ];
   const layout = baseLayout("Impact on Buy − Rent difference");
-  clearCurrencyFromYAxis(layout);
+  moveCurrencyToXAxis(layout);
   layout.barmode = "overlay";
   layout.yaxis.automargin = true; // grow the left margin to fit parameter labels
   layout.shapes = [
@@ -224,7 +230,7 @@ export function renderBreakdownChart(el, payload, cfg) {
     },
   ];
   const layout = baseLayout(`Total over ${cfg.horizonYears} years`);
-  clearCurrencyFromYAxis(layout);
+  moveCurrencyToXAxis(layout);
   layout.yaxis.automargin = true; // grow the left margin to fit category labels
   Plotly.react(el, traces, layout, PLOT_CONFIG);
 }

--- a/tests/test_chart_axes.py
+++ b/tests/test_chart_axes.py
@@ -1,0 +1,77 @@
+"""Chart axis contract, parsed out of charts.js.
+
+There is no JS test harness in this repo, so this regex parse is the
+only automated guard on the money axis -- the same approach
+``tests/test_regions.py`` already uses for ``fields.js``.
+
+It exists because of a real regression: the currency moved from
+``tickformat: "$~s"`` to a separate ``tickprefix`` when multi-currency
+shipped, and the horizontal-bar helper still only DELETED the y-axis
+formatting. Money on those charts is on X, which was left with no
+currency and no SI compaction -- the tornado read "-0.5M" where every
+other chart read "-EUR500k".
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+_CHARTS_JS = Path(__file__).parent.parent / "src/simulator/static/js/charts.js"
+
+
+def _source() -> str:
+    return _CHARTS_JS.read_text(encoding="utf-8")
+
+
+def _helper_body() -> str:
+    """The body of the horizontal-bar axis helper.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        assert "xaxis.tickprefix" in _helper_body()
+
+    """
+    match = re.search(
+        r"function moveCurrencyToXAxis\(layout\)\s*\{(?P<body>.*?)\n\}",
+        _source(),
+        re.S,
+    )
+    assert match, "moveCurrencyToXAxis not found in charts.js"
+    return match.group("body")
+
+
+class TestHorizontalBarMoneyAxis:
+    """Tornado and breakdown put money on X, categories on Y."""
+
+    def test_helper_assigns_currency_to_the_x_axis(self):
+        # The regression was a helper that only deleted. Assigning to X is
+        # the whole fix, so assert the assignment rather than its absence
+        # from Y.
+        body = _helper_body()
+        assert "xaxis.tickprefix" in body
+        assert "xaxis.tickformat" in body
+
+    def test_helper_clears_currency_from_the_category_axis(self):
+        # Plotly ignores a tickformat on a category axis but honours a
+        # tickprefix, so a prefix left on Y renders every parameter name
+        # as "<symbol>Rent Inflation".
+        body = _helper_body()
+        assert "delete layout.yaxis.tickprefix" in body
+        assert "delete layout.yaxis.tickformat" in body
+
+    def test_both_horizontal_bar_charts_use_the_helper(self):
+        # Tornado and breakdown are the only two; if a third horizontal
+        # bar chart is added it must opt in or ship an unlabelled axis.
+        source = _source()
+        assert source.count("moveCurrencyToXAxis(layout);") == 2
+
+    def test_base_layout_still_puts_money_on_the_y_axis(self):
+        # The helper moves what baseLayout sets. If baseLayout stops
+        # setting a tickprefix, the helper silently propagates undefined.
+        match = re.search(r"function baseLayout\(.*?\n\}", _source(), re.S)
+        assert match
+        assert "tickprefix: getCurrencySymbol()" in match.group(0)

--- a/tests/test_chart_axes.py
+++ b/tests/test_chart_axes.py
@@ -1,22 +1,26 @@
 """Chart axis contract, parsed out of charts.js.
 
-There is no JS test harness in this repo, so this regex parse is the
-only automated guard on the money axis -- the same approach
-``tests/test_regions.py`` already uses for ``fields.js``.
+There is no JS test harness in this repo, so this parse is the only
+automated guard on the money axis -- the same approach
+``tests/test_regions.py`` uses for ``fields.js``.
 
-It exists because of a real regression: the currency moved from
-``tickformat: "$~s"`` to a separate ``tickprefix`` when multi-currency
-shipped, and the horizontal-bar helper still only DELETED the y-axis
-formatting. Money on those charts is on X, which was left with no
-currency and no SI compaction -- the tornado read "-0.5M" where every
-other chart read "-EUR500k".
+**What this does and does not buy.** It is a STRUCTURAL guard: it checks
+that the helper moves the money formatting to the axis that carries
+money, and that both horizontal-bar charts call it. It does NOT render
+anything, so it cannot prove Plotly draws the result correctly -- that
+rests on the manual browser pass recorded in the PR.
+
+An earlier version of this file asserted only that the substrings
+``"xaxis.tickprefix"`` and ``"xaxis.tickformat"`` appeared somewhere in
+the helper. Three mutations passed it, including
+``layout.xaxis.tickprefix = undefined``, which is exactly the regression
+the helper exists to prevent, and commenting out both call sites, which a
+raw ``count()`` scored as present. The assertions below check the
+assignment PAIRING and strip comments before counting.
 """
 
 import re
-import sys
 from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 _CHARTS_JS = Path(__file__).parent.parent / "src/simulator/static/js/charts.js"
 
@@ -25,19 +29,35 @@ def _source() -> str:
     return _CHARTS_JS.read_text(encoding="utf-8")
 
 
-def _helper_body() -> str:
-    """The body of the horizontal-bar axis helper.
+def _strip_comments(source: str) -> str:
+    """Source with ``//`` and ``/* */`` comments removed.
+
+    Counting call sites in raw text scores a commented-out call as live.
 
     Examples
     --------
     .. code-block:: python
 
-        assert "xaxis.tickprefix" in _helper_body()
+        assert _strip_comments("a(); // b();").strip() == "a();"
+
+    """
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def _helper_body() -> str:
+    """Body of the horizontal-bar axis helper, comments stripped.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        assert "xaxis" in _helper_body()
 
     """
     match = re.search(
         r"function moveCurrencyToXAxis\(layout\)\s*\{(?P<body>.*?)\n\}",
-        _source(),
+        _strip_comments(_source()),
         re.S,
     )
     assert match, "moveCurrencyToXAxis not found in charts.js"
@@ -47,13 +67,15 @@ def _helper_body() -> str:
 class TestHorizontalBarMoneyAxis:
     """Tornado and breakdown put money on X, categories on Y."""
 
-    def test_helper_assigns_currency_to_the_x_axis(self):
-        # The regression was a helper that only deleted. Assigning to X is
-        # the whole fix, so assert the assignment rather than its absence
-        # from Y.
+    def test_x_axis_takes_its_value_from_the_matching_y_axis_key(self):
+        # Pairing, not presence. `xaxis.tickprefix = undefined` and
+        # `xaxis.tickprefix = yaxis.tickformat` both satisfy a substring
+        # check while leaving the axis unlabelled or mislabelled.
         body = _helper_body()
-        assert "xaxis.tickprefix" in body
-        assert "xaxis.tickformat" in body
+        for key in ("tickprefix", "tickformat"):
+            assert re.search(
+                rf"layout\.xaxis\.{key}\s*=\s*layout\.yaxis\.{key}\s*;", body
+            ), f"xaxis.{key} is not assigned from yaxis.{key}"
 
     def test_helper_clears_currency_from_the_category_axis(self):
         # Plotly ignores a tickformat on a category axis but honours a
@@ -63,15 +85,24 @@ class TestHorizontalBarMoneyAxis:
         assert "delete layout.yaxis.tickprefix" in body
         assert "delete layout.yaxis.tickformat" in body
 
+    def test_helper_refuses_to_run_twice(self):
+        # The second call would read the already-deleted y-axis keys and
+        # assign undefined, wiping the currency it just installed.
+        assert re.search(
+            r"if\s*\(layout\.yaxis\.tickprefix === undefined\)\s*return;",
+            _helper_body(),
+        ), "moveCurrencyToXAxis has no guard against a second call"
+
     def test_both_horizontal_bar_charts_use_the_helper(self):
-        # Tornado and breakdown are the only two; if a third horizontal
-        # bar chart is added it must opt in or ship an unlabelled axis.
-        source = _source()
-        assert source.count("moveCurrencyToXAxis(layout);") == 2
+        # Comments stripped first: a commented-out call is not a call.
+        live = _strip_comments(_source())
+        assert live.count("moveCurrencyToXAxis(layout);") == 2
 
     def test_base_layout_still_puts_money_on_the_y_axis(self):
         # The helper moves what baseLayout sets. If baseLayout stops
         # setting a tickprefix, the helper silently propagates undefined.
-        match = re.search(r"function baseLayout\(.*?\n\}", _source(), re.S)
+        match = re.search(
+            r"function baseLayout\(.*?\n\}", _strip_comments(_source()), re.S
+        )
         assert match
         assert "tickprefix: getCurrencySymbol()" in match.group(0)

--- a/tests/test_monte_carlo.py
+++ b/tests/test_monte_carlo.py
@@ -72,13 +72,17 @@ class TestSensitivity:
 
     def test_tornado_low_uses_negative_growth_rate(self):
         # Equity Growth low perturbation must reflect the true negative rate,
-        # not a clamped near-zero floor. With default std=15, the low target
-        # for equity_growth_annual=7.0 is -8.0.
-        base_cfg = make_config(equity_growth_annual=7.0)
+        # not a clamped near-zero floor. The delta is now the standard error,
+        # std/sqrt(horizon), so a 1-year horizon takes the full std=15 and the
+        # low target for equity_growth_annual=7.0 is -8.0 -- unchanged from
+        # when the delta was the raw std. This is deliberately the horizon at
+        # which the perturbation still goes negative, because a negative
+        # target is what proves nothing floors it at zero.
+        base_cfg = make_config(horizon_years=1, equity_growth_annual=7.0)
         names, low, _high, _base = _compute_sensitivity(base_cfg)
         idx = names.index("Equity Growth")
         expected_low = calculate_scenarios(
-            make_config(equity_growth_annual=-8.0)
+            make_config(horizon_years=1, equity_growth_annual=-8.0)
         ).final_difference
         assert abs(low[idx] - expected_low) < 1e-6
 
@@ -149,7 +153,7 @@ class TestTornadoLevyDelta:
     def test_zero_levy_region_drops_the_bar(self):
         # UK/DE/FR ship propertyTaxRate 0.0. A proportional delta at a
         # zero base is itself zero, and _compute_sensitivity would then
-        # floor the low side at _LOW_PERTURBATION_FLOOR while the high
+        # floor the low side at _POSITIVE_FIELD_FLOOR while the high
         # side stayed 0 -- producing a tiny INVERTED bar rather than no
         # bar. Hence the skip is kept alongside the proportional delta.
         # The guard covers the whole near-zero band, not just an exact

--- a/tests/test_tornado_bounds.py
+++ b/tests/test_tornado_bounds.py
@@ -1,6 +1,6 @@
 """The tornado's high perturbations must stay inside the UI's own range.
 
-``_PERTURBATION_CEILING`` hand-mirrors the slider maxima in fields.js
+``_UI_MAXIMUM`` hand-mirrors the slider maxima in fields.js
 because the engine cannot read JavaScript. This module parses those
 maxima and asserts the copy is honest -- the same approach
 ``tests/test_regions.py`` uses for bundle values.
@@ -19,24 +19,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
+from simulator.api import _camel
 from simulator.engine import calculate_scenarios
 from simulator.models import MonteCarloConfig, SimulationConfig
-from simulator.monte_carlo import _PERTURBATION_CEILING, _compute_sensitivity
+from simulator.monte_carlo import _UI_MAXIMUM, _compute_sensitivity
 
 _FIELDS_JS = Path(__file__).parent.parent / "src/simulator/static/js/fields.js"
-
-# Wire (camelCase) name for each engine field that carries a ceiling.
-_WIRE_NAME = {
-    "property_appreciation_annual": "propertyAppreciationAnnual",
-    "equity_growth_annual": "equityGrowthAnnual",
-    "rent_inflation_rate": "rentInflationRate",
-    "property_price": "propertyPrice",
-    "down_payment_pct": "downPaymentPct",
-    "monthly_rent": "monthlyRent",
-    "mortgage_rate_annual": "mortgageRateAnnual",
-    "property_tax_rate": "propertyTaxRate",
-    "annual_property_levy": "annualPropertyLevy",
-}
 
 
 def _slider_maxima() -> dict[str, Fraction]:
@@ -63,8 +51,15 @@ def _slider_maxima() -> dict[str, Fraction]:
 class TestCeilingsMatchTheUi:
     def test_every_ceiling_equals_its_slider_maximum(self):
         maxima = _slider_maxima()
-        for field, ceiling in _PERTURBATION_CEILING.items():
-            wire = _WIRE_NAME[field]
+        for field, ceiling in _UI_MAXIMUM.items():
+            wire = _camel(field)
+            # A Prettier run that wraps a fields.js entry across lines
+            # drops it from this line-oriented parse. Say so, rather
+            # than raising a KeyError that reads as a broken ceiling.
+            assert wire in maxima, (
+                f"{wire} was not parsed out of fields.js -- is its "
+                "INPUT_DEFS entry wrapped across multiple lines?"
+            )
             assert Fraction(str(ceiling)) == maxima[wire], (
                 f"{field}: ceiling {ceiling} != fields.js max "
                 f"{float(maxima[wire])} for {wire}"
@@ -80,7 +75,7 @@ class TestCeilingsMatchTheUi:
         assert block
         fields = re.findall(r'"[^"]+",\s*"(\w+)"', block.group("body"))
         assert fields, "could not parse the perturbation list"
-        missing = [f for f in fields if f not in _PERTURBATION_CEILING]
+        missing = [f for f in fields if f not in _UI_MAXIMUM]
         assert not missing, f"perturbed without a ceiling: {missing}"
 
 
@@ -106,14 +101,77 @@ class TestHighSideIsBounded:
         # the widest one.
         assert min(spans.values()) / widest > 0.005
 
-    def test_low_side_still_reaches_genuinely_negative_growth(self):
-        # The cap is deliberately ASYMMETRIC. A crash is a real outcome
-        # the model must represent even though the slider floor is 0, so
-        # capping the low side too would be a behaviour regression.
+    def test_a_base_above_its_ceiling_never_inverts_the_bar(self):
+        # The engine accepts bases above the slider maximum -- down
+        # payment is valid to 100, the slider stops at 50 -- and a config
+        # can arrive that way through the API. Clamping to the ceiling
+        # alone put the "higher" bar BELOW the base and below the "lower"
+        # bar, so both landed on the same side of the pivot and the one
+        # labelled "higher" showed the outcome of a DECREASE.
+        for field, value in (
+            ("down_payment_pct", 90.0),
+            ("equity_growth_annual", 20.0),
+            ("property_tax_rate", 40.0),
+        ):
+            kwargs = {
+                "horizon_years": 10,
+                "property_price": 500_000,
+                "down_payment_pct": 20,
+                "mortgage_rate_annual": 6.5,
+                "property_appreciation_annual": 3.0,
+                "equity_growth_annual": 7.0,
+                "monthly_rent": 2400,
+                field: value,
+            }
+            names, low, high, base = _compute_sensitivity(SimulationConfig(**kwargs))
+            label = {
+                "down_payment_pct": "Down Payment %",
+                "equity_growth_annual": "Equity Growth",
+                "property_tax_rate": "Property Tax Rate",
+            }[field]
+            if label not in names:
+                continue
+            i = names.index(label)
+            assert (low[i] > base) != (high[i] > base) or high[i] == base, (
+                f"{field}={value}: low {low[i]:,.0f} and high {high[i]:,.0f} "
+                f"are on the same side of base {base:,.0f}"
+            )
+
+    def test_ceiling_never_collapses_a_real_levy_bar(self):
+        # The levy delta is proportional, so there is an exact base where
+        # the low side lands ON the ceiling while the high side is
+        # clamped TO it. The swing became exactly zero and the
+        # negligible-swing guard -- meant for structural cancellation --
+        # deleted a large, real cost from the chart.
+        for levy in (10_000.0, 10_000 / 0.5833333333333334, 20_000.0):
+            config = SimulationConfig(
+                horizon_years=10,
+                property_price=500_000,
+                down_payment_pct=20,
+                mortgage_rate_annual=6.5,
+                property_appreciation_annual=3.0,
+                equity_growth_annual=7.0,
+                monthly_rent=2400,
+                property_tax_rate=0.0,
+                annual_property_levy=levy,
+            )
+            names, _, _, _ = _compute_sensitivity(config)
+            assert "Property Levy (flat)" in names, (
+                f"levy {levy:,.2f}: a real, owner-borne cost lost its bar"
+            )
+
+    def test_low_side_is_never_floored_at_the_slider_minimum(self):
+        # The cap is deliberately ASYMMETRIC: only the high side is
+        # bounded by the UI. The low side must remain the true perturbed
+        # value even when that is below the slider floor of 0, because a
+        # crash is a real outcome the model has to represent.
+        #
+        # At a 1-year horizon the standard error is the full std of 15,
+        # so the low target is 7 - 15 = -8%.
         base = 7.0
         std = MonteCarloConfig().equity_growth_std
         config = SimulationConfig(
-            horizon_years=10,
+            horizon_years=1,
             property_price=500_000,
             down_payment_pct=20,
             mortgage_rate_annual=6.5,
@@ -126,7 +184,7 @@ class TestHighSideIsBounded:
         expected = calculate_scenarios(
             dataclasses.replace(config, equity_growth_annual=base - std)
         ).final_difference
-        # The low bar must still be the outcome at -8%, NOT at the slider
-        # floor of 0. If a future change caps the low side too, this is
-        # the assertion that catches it.
+        # Same code path and same inputs on both sides, so these are
+        # bit-identical by construction and exact equality is the
+        # assertion -- approx would hide a floor being applied.
         assert low[names.index("Equity Growth")] == expected

--- a/tests/test_tornado_bounds.py
+++ b/tests/test_tornado_bounds.py
@@ -1,0 +1,132 @@
+"""The tornado's high perturbations must stay inside the UI's own range.
+
+``_PERTURBATION_CEILING`` hand-mirrors the slider maxima in fields.js
+because the engine cannot read JavaScript. This module parses those
+maxima and asserts the copy is honest -- the same approach
+``tests/test_regions.py`` uses for bundle values.
+
+Without the cap the tornado measured configurations the app cannot
+produce: equity growth swung to +1 sigma = 22-24% against a slider that
+stops at 15%, which over a long horizon compounds into a bar an order of
+magnitude wider than every other one combined.
+"""
+
+import dataclasses
+import re
+import sys
+from fractions import Fraction
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from simulator.engine import calculate_scenarios
+from simulator.models import MonteCarloConfig, SimulationConfig
+from simulator.monte_carlo import _PERTURBATION_CEILING, _compute_sensitivity
+
+_FIELDS_JS = Path(__file__).parent.parent / "src/simulator/static/js/fields.js"
+
+# Wire (camelCase) name for each engine field that carries a ceiling.
+_WIRE_NAME = {
+    "property_appreciation_annual": "propertyAppreciationAnnual",
+    "equity_growth_annual": "equityGrowthAnnual",
+    "rent_inflation_rate": "rentInflationRate",
+    "property_price": "propertyPrice",
+    "down_payment_pct": "downPaymentPct",
+    "monthly_rent": "monthlyRent",
+    "mortgage_rate_annual": "mortgageRateAnnual",
+    "property_tax_rate": "propertyTaxRate",
+    "annual_property_levy": "annualPropertyLevy",
+}
+
+
+def _slider_maxima() -> dict[str, Fraction]:
+    """Slider maxima from fields.js, converted to STORED units.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        assert _slider_maxima()["equityGrowthAnnual"] == 15
+
+    """
+    maxima: dict[str, Fraction] = {}
+    pattern = re.compile(r'key:\s*"(?P<key>\w+)".*?max:\s*(?P<max>-?[\d.]+)')
+    for line in _FIELDS_JS.read_text(encoding="utf-8").splitlines():
+        match = pattern.search(line)
+        if match:
+            scale_match = re.search(r"scale:\s*([\d.]+)", line)
+            scale = Fraction(scale_match.group(1)) if scale_match else Fraction(1)
+            maxima[match.group("key")] = Fraction(match.group("max")) / scale
+    return maxima
+
+
+class TestCeilingsMatchTheUi:
+    def test_every_ceiling_equals_its_slider_maximum(self):
+        maxima = _slider_maxima()
+        for field, ceiling in _PERTURBATION_CEILING.items():
+            wire = _WIRE_NAME[field]
+            assert Fraction(str(ceiling)) == maxima[wire], (
+                f"{field}: ceiling {ceiling} != fields.js max "
+                f"{float(maxima[wire])} for {wire}"
+            )
+
+    def test_every_perturbed_field_declares_a_ceiling(self):
+        # A perturbation with no ceiling silently reverts to the old
+        # unbounded behaviour for that field.
+        source = (
+            Path(__file__).parent.parent / "src/simulator/monte_carlo.py"
+        ).read_text()
+        block = re.search(r"perturbations = \[(?P<body>.*?)\n    \]", source, re.S)
+        assert block
+        fields = re.findall(r'"[^"]+",\s*"(\w+)"', block.group("body"))
+        assert fields, "could not parse the perturbation list"
+        missing = [f for f in fields if f not in _PERTURBATION_CEILING]
+        assert not missing, f"perturbed without a ceiling: {missing}"
+
+
+class TestHighSideIsBounded:
+    def test_equity_growth_stops_at_the_slider_maximum(self):
+        # The reported case: a long horizon turned the unbounded +1 sigma
+        # into a bar that dwarfed the whole chart.
+        config = SimulationConfig(
+            horizon_years=22,
+            property_price=750_000,
+            down_payment_pct=20,
+            mortgage_rate_annual=3.45,
+            property_appreciation_annual=3.0,
+            equity_growth_annual=9.0,
+            monthly_rent=2200,
+        )
+        names, low, high, _ = _compute_sensitivity(config)
+        spans = {n: abs(high[i] - low[i]) for i, n in enumerate(names)}
+        widest = max(spans.values())
+        # Unbounded, equity spanned ~33.7M against a ~0.5M median bar.
+        assert widest < 10_000_000, f"widest bar {widest:,.0f} is still runaway"
+        # And the chart stays readable: no bar is a rounding error next to
+        # the widest one.
+        assert min(spans.values()) / widest > 0.005
+
+    def test_low_side_still_reaches_genuinely_negative_growth(self):
+        # The cap is deliberately ASYMMETRIC. A crash is a real outcome
+        # the model must represent even though the slider floor is 0, so
+        # capping the low side too would be a behaviour regression.
+        base = 7.0
+        std = MonteCarloConfig().equity_growth_std
+        config = SimulationConfig(
+            horizon_years=10,
+            property_price=500_000,
+            down_payment_pct=20,
+            mortgage_rate_annual=6.5,
+            property_appreciation_annual=3.0,
+            equity_growth_annual=base,
+            monthly_rent=2400,
+        )
+        assert base - std < 0, "test presumes the low perturbation goes negative"
+        names, low, _high, _ = _compute_sensitivity(config)
+        expected = calculate_scenarios(
+            dataclasses.replace(config, equity_growth_annual=base - std)
+        ).final_difference
+        # The low bar must still be the outcome at -8%, NOT at the slider
+        # floor of 0. If a future change caps the low side too, this is
+        # the assertion that catches it.
+        assert low[names.index("Equity Growth")] == expected

--- a/tests/test_us_regression.py
+++ b/tests/test_us_regression.py
@@ -46,13 +46,22 @@ GOLDENS = {
     "total_tax_savings": 74968.2878800427,
 }
 
-# The 8 tornado bars, in rank order, captured at the same commit. T9
-# changes how the levy delta is computed; these pin that the US chart
-# does not move. _compute_sensitivity orders by descending impact
-# range, so a reordering is itself a regression.
+# The 8 tornado bars, in rank order. _compute_sensitivity orders by
+# descending impact range, so a reordering is itself a regression.
+#
+# REGENERATED once, deliberately, when high perturbations were capped at
+# the UI's slider maximum (_PERTURBATION_CEILING). Only two values moved
+# and both were provably out of the app's own configurable range before:
+# Equity Growth high 22% -> 15% and Property Appreciation high 11% -> 10%.
+# EVERY low value is bit-identical, and six of the eight bars are
+# untouched on both sides. The rank flip is the point: bounded to what a
+# user can actually set, property prices drive the US verdict harder than
+# the equity tail does. Do not regenerate these to make a failure pass --
+# diff them by NAME (the order moves) and justify every value that
+# changes.
 TORNADO_NAMES = [
-    "Equity Growth",
     "Property Appreciation",
+    "Equity Growth",
     "Monthly Rent",
     "Property Price",
     "Mortgage Rate",
@@ -61,8 +70,8 @@ TORNADO_NAMES = [
     "Down Payment %",
 ]
 TORNADO_LOW = [
-    245518.11238156457,
     -302415.7909909935,
+    245518.11238156457,
     -93421.86072197475,
     88181.87658442234,
     43093.40687027981,
@@ -71,8 +80,8 @@ TORNADO_LOW = [
     4054.6262869769125,
 ]
 TORNADO_HIGH = [
-    -890777.8509134441,
-    579807.9025580233,
+    481401.7741232437,
+    -325181.2971145665,
     95917.84863319725,
     -85685.88867319992,
     -41503.53846349695,

--- a/tests/test_us_regression.py
+++ b/tests/test_us_regression.py
@@ -5,6 +5,11 @@ US region bundle's defaults at commit f585e98, BEFORE any multi-region
 engine primitive existed (docs/multi-region-spec.md 7.2). A failure here
 means a "default-inert" primitive is not inert. Never regenerate these
 numbers to make a test pass -- find the primitive that leaked instead.
+
+The GOLDENS block below is engine output and has never been regenerated.
+The TORNADO_* constants are perturbation output, and have been
+regenerated twice, deliberately, when the perturbation rule itself was
+redefined; see the note above them for the standard that applies.
 """
 
 import sys
@@ -49,19 +54,28 @@ GOLDENS = {
 # The 8 tornado bars, in rank order. _compute_sensitivity orders by
 # descending impact range, so a reordering is itself a regression.
 #
-# REGENERATED once, deliberately, when high perturbations were capped at
-# the UI's slider maximum (_PERTURBATION_CEILING). Only two values moved
-# and both were provably out of the app's own configurable range before:
-# Equity Growth high 22% -> 15% and Property Appreciation high 11% -> 10%.
-# EVERY low value is bit-identical, and six of the eight bars are
-# untouched on both sides. The rank flip is the point: bounded to what a
-# user can actually set, property prices drive the US verdict harder than
-# the equity tail does. Do not regenerate these to make a failure pass --
-# diff them by NAME (the order moves) and justify every value that
-# changes.
+# REGENERATED deliberately, when the tornado's delta for the three
+# stochastic drivers became the standard error of the long-run average
+# (std / sqrt(horizon)) instead of the raw annual std. The annual figure
+# is what run_monte_carlo needs for year-to-year draws; the tornado holds
+# its shift for the whole horizon, so it needs the uncertainty of the
+# AVERAGE. Diffed by NAME, since the rank order moves:
+#
+#   - the three stochastic bars move on BOTH sides, because the delta
+#     itself shrank: Equity Growth, Property Appreciation, Rent Inflation
+#   - the five fixed-step bars are bit-identical on both sides: Monthly
+#     Rent, Property Price, Mortgage Rate, Property Tax Rate, Down
+#     Payment % -- their deltas are absolute steps, not standard
+#     deviations, so sqrt(horizon) does not apply
+#   - the summary GOLDENS block above is untouched
+#
+# Do not regenerate these to make a failure pass. Diff by NAME and
+# justify every value that moves: an engine change should move nothing
+# here, and a deliberate perturbation change should move exactly the
+# fields it redefines.
 TORNADO_NAMES = [
-    "Property Appreciation",
     "Equity Growth",
+    "Property Appreciation",
     "Monthly Rent",
     "Property Price",
     "Mortgage Rate",
@@ -70,23 +84,23 @@ TORNADO_NAMES = [
     "Down Payment %",
 ]
 TORNADO_LOW = [
-    -302415.7909909935,
-    245518.11238156457,
+    108315.2700715856,
+    -123364.65793813154,
     -93421.86072197475,
     88181.87658442234,
     43093.40687027981,
     33706.69579412212,
-    -29181.80117805692,
+    -8688.793081999,
     4054.6262869769125,
 ]
 TORNADO_HIGH = [
-    481401.7741232437,
-    -325181.2971145665,
+    -163200.45114455867,
+    145428.83590766793,
     95917.84863319725,
     -85685.88867319992,
     -41503.53846349695,
     -31976.807946117828,
-    34725.09155147744,
+    11489.229746876867,
     -1558.6383757545846,
 ]
 TORNADO_BASE = 1247.9939556111349


### PR DESCRIPTION
## Summary

Two display defects in the tornado and breakdown charts, reported after #40 merged: the money axis lost its currency symbol, and one bar spanned €33M while the other seven were slivers. Hotfix off `main` (`27caaaa`).

## 1. Money axis had no currency and no SI compaction

The tornado and breakdown x-axes rendered bare numbers — `-0.5M`, `50k` — while every other chart showed `€-500k`.

Both charts put money on **X** and categories on **Y**, and the horizontal-bar helper only *deleted* the y-axis money formatting without applying it to X. Root cause is a missed call site in #40: before it, currency lived in `tickformat: "$~s"`, a single property, so deleting the y-axis formatting removed the currency with it. #40 split the two — `tickprefix` for the symbol, `tickformat: "~s"` for compaction — and the helper kept deleting both.

They cannot simply be set on both axes: Plotly ignores a `tickformat` on a category axis but honours a `tickprefix`, so a prefix left on Y labels every category `€Rent Inflation`.

| Chart | Before | After |
|---|---|---|
| Tornado (x) | `-30M, -25M, -20M` | `€-1.5M, €-1M, €-500k` |
| Breakdown (x) | `0, 50k, 100k, 150k` | `€0, €50k, €100k, €150k, €200k` |

## 2. The tornado perturbed by annual σ instead of the standard error

`equity_growth_std = 15.0` is the **annual** standard deviation. That is the right scale for `run_monte_carlo`, which redraws every year. The tornado does something different: it shifts the single long-run average and holds it for the whole horizon. The uncertainty that applies there is the uncertainty of that *average* — the standard error, `σ / √horizon`.

Conflating the two moved a 9% equity CAGR to 24% and held it for 22 years, compounding a €150k outlay into ~€17M and producing a €33.7M bar against a €203k verdict.

The three stochastic drivers now use `σ / √horizon` (3.2pp at 22 years). The other deltas are fixed absolute steps, not standard deviations, so `√horizon` does not apply and they are untouched.

On the reported config the axis goes from `€-30M…€5M` to `€-1.5M…€500k`, and the bars become a real distribution instead of one spike:

```
Equity Growth          2,129,456  (100.0%)
Property Appreciation  1,043,978   (49.0%)
Monthly Rent             838,365   (39.4%)
Property Price           495,427   (23.3%)
Mortgage Rate            383,403   (18.0%)
Down Payment %           123,433    (5.8%)
Rent Inflation           107,262    (5.0%)
Property Levy (flat)      67,905    (3.2%)   <- was ~0.6%
```

A high perturbation is additionally capped at the parameter's slider maximum, so the chart never measures a configuration the app cannot be set to. The cap is **one-sided**: the low side may fall below the slider minimum, because a crash is a real outcome the model must represent even though the UI will not let you type a negative growth rate.

## What the adversarial review caught

Three personas, nine findings. Two invalidated an earlier version of this PR and are worth calling out, because they were mine:

**The first ceiling attempt made the high bar a constant.** The ceiling (15.0) and the perturbation width (15.0) were the same number, so `min(base + 15, 15) == 15` for every base on the slider. Swept: the high bar read `-325,181.30` at base 0.1%, 3%, 7%, 9%, 12% and 15% — identical. Half the chart had stopped responding to input on the default view of all five regions. That is what forced the root-cause fix above.

**`tests/test_chart_axes.py` was substring ceremony.** Three mutations passed it, including `layout.xaxis.tickprefix = undefined` — precisely the regression it exists to catch — and commenting out both call sites, which a raw `count()` scored as present. My "mutation-checked" claim on the first commit was true only of the one revert I happened to try. It now checks assignment *pairing* and strips comments before counting; all four mutations fail it. Its docstring states plainly that it is a structural guard and cannot prove Plotly renders anything.

Also fixed from the review: the ceiling could put the "higher" bar *below* the base (both bars on the same side of the pivot, the one labelled "higher" showing a decrease) and could collapse a real levy bar to zero swing; `moveCurrencyToXAxis` now refuses to run twice; `_WIRE_NAME` deleted in favour of `api._camel`, which it reimplemented verbatim; `_PERTURBATION_CEILING`/`_LOW_PERTURBATION_FLOOR` renamed to `_UI_MAXIMUM`/`_POSITIVE_FIELD_FLOOR` since they read as an antonym pair but are a UI policy and a numeric safety floor.

## Review guide

| Area | Why |
|---|---|
| `monte_carlo.py` `_STOCHASTIC_FIELDS` | The conceptual change. σ vs σ/√N is the whole fix. |
| `monte_carlo.py` high-perturbation clamp | The outer `max(base_val, …)` is load-bearing, not defensive. |
| `tests/test_us_regression.py` | Goldens regenerated. Diff by **name** — the rank order moves. |

**Goldens.** Regenerated deliberately: the three stochastic bars move on both sides because the delta itself shrank; the five fixed-step bars are bit-identical on both sides; the summary `GOLDENS` block is untouched. The module docstring no longer contradicts the block — it distinguishes engine output, never regenerated, from perturbation output, regenerated only when the rule is redefined.

**One pre-existing assertion updated.** `test_tornado_low_uses_negative_growth_rate` hard-coded a `-8.0` low target tied to the raw std. Its intent — that nothing floors the low side at zero — is preserved exactly, including the `-8.0`, by running it at a 1-year horizon where the standard error *is* the full std. That is deliberately the horizon at which the perturbation still goes negative, which is the case that proves the point.

## Symlog — checked, not broken

Worth recording since it prompted the report. Symlog applies to the decision and outflow *line* charts and never applied to the bar charts. Driving `renderDecisionChart` with disparate series installs `tickmode: "array"` and renders the 1×/3× decade ladder correctly: `-€10k, €0, €10k, €30k, €100k, €300k, €1.0M`. A leftover `tickprefix` is harmless there — Plotly ignores it when explicit `ticktext` is supplied, so there is no doubled symbol. I suspected `€€1M` and verified it away.

## Testing

- [x] **207 tests pass** (200 at branch point), **92.89% coverage**, `ty` / `ruff check` / `ruff format --check` clean
- [x] Mutation-checked in both directions: reverting the clamp fails the new tornado tests; all four charts.js mutations fail the rewritten axis tests
- [x] Browser-verified on the reported config: eight legible bars, currency on both money axes, category labels unprefixed, console clean
- [x] Swept 324 configs for zero-width levy bars, 27 for ordering ties — none

## Breaking changes

None to the API or share URLs. The tornado's perturbation width changes, which changes the chart — that is the fix.
